### PR TITLE
Bugfix/typo in services yaml

### DIFF
--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -1,4 +1,4 @@
 services:
     HalloVerden\DoctrineSqlLoggerBundle\Loggers\QueryExecutionTimeLogger:
         arguments:
-            $executionTimelogger: '@logger'
+            $executionTimeLogger: '@logger'


### PR DESCRIPTION
missing captial L in $executionTimeLogger for QueryExecutionTimeLogger service definition in services.yaml

fixes #3 